### PR TITLE
Handle missing road data

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, send_file, render_template
+from flask import Flask, send_file, render_template, jsonify
 from flask_cors import CORS
 import os
 
@@ -13,6 +13,9 @@ def home():
 
 @app.route("/api/roads")
 def get_roads():
+    if not os.path.exists(DATA_PATH):
+        # Return a 404 response if the GeoJSON file is missing
+        return jsonify({"error": "Road data not found"}), 404
     return send_file(DATA_PATH, mimetype="application/geo+json")
 
 if __name__ == "__main__": # pragma: no cover

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -27,3 +27,17 @@ def test_home_route(client):
     response = client.get("/")
     assert response.status_code == 200
     assert b"<html" in response.data  # or some other check for the HTML
+
+
+def test_get_roads_not_found(tmp_path, monkeypatch):
+    """Ensure a 404 response is returned when the GeoJSON file is missing."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    missing = data_dir / "missing.geojson"
+    monkeypatch.setattr(app, "DATA_PATH", str(missing))
+    monkeypatch.chdir(tmp_path)
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        response = client.get("/api/roads")
+        assert response.status_code == 404
+        assert b"Road data not found" in response.data


### PR DESCRIPTION
## Summary
- handle missing GeoJSON file in the API
- test 404 response when road data is missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6859877766408323bf6491ec8e2f5367