### PR TITLE
Pin dependencies versions

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest
-pytest-cov
-flake8
-pylint
+pytest==7.4.0
+pytest-cov==4.1.0
+flake8==6.0.0
+pylint==2.17.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Flask
-flask-cors
-osmnx
-geopandas
-networkx
-shapely
-matplotlib
-pyproj
+Flask==2.3.2
+flask-cors==3.0.10
+osmnx==1.3.0
+geopandas==0.14.0
+networkx==2.8.8
+shapely==2.0.1
+matplotlib==3.7.1
+pyproj==3.6.0


### PR DESCRIPTION
## Summary
- pin dependencies in requirements.txt
- pin dev dependencies in requirements-dev.txt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68598822164083239f54627a78d55d9e