### PR TITLE
Update docs for data download step

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ python generate_geojson.py
 python app.py
 ```
 
+The `generate_geojson.py` script downloads road data from OpenStreetMap and may require a stable
+internet connection. The output file will be saved as `data/birmingham_roads.geojson`.
+
 Then go to http://127.0.0.1:5000
 
 ## Testing


### PR DESCRIPTION
## Summary
- clarify that `generate_geojson.py` downloads data from OpenStreetMap and requires internet
- mention output file `data/birmingham_roads.geojson`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68598a4354a08323a2422c77159db9e9