### PR TITLE
Organize app into package

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An interactive web app that lets you search, visualise, and explore road data fo
 pip install -r requirements.txt
 pip install -r requirements-dev.txt  # for running tests
 python generate_geojson.py
-python app.py
+python -m brumapp.app
 ```
 
 The `generate_geojson.py` script downloads road data from OpenStreetMap and may require a stable

--- a/brumapp/__init__.py
+++ b/brumapp/__init__.py
@@ -1,0 +1,3 @@
+from .app import app
+
+__all__ = ["app"]

--- a/brumapp/app.py
+++ b/brumapp/app.py
@@ -2,10 +2,19 @@ from flask import Flask, send_file, render_template, jsonify
 from flask_cors import CORS
 import os
 
-app = Flask(__name__)
+# Determine the project root (one level above this file)
+BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+# Point Flask at the root level ``templates`` and ``static`` folders
+app = Flask(
+    __name__,
+    static_folder=os.path.join(BASE_DIR, "static"),
+    template_folder=os.path.join(BASE_DIR, "templates"),
+)
 CORS(app)  # Allow requests from frontend
 
-DATA_PATH = os.path.join(os.path.dirname(__file__), "data", "birmingham_roads.geojson")
+# Default path to the GeoJSON data
+DATA_PATH = os.path.join(BASE_DIR, "data", "birmingham_roads.geojson")
 
 @app.route("/")
 def home():

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,7 +3,7 @@ import os
 import pytest
 import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from app import app
+from brumapp import app
 
 @pytest.fixture
 def client(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- package the Flask app as `brumapp`
- update tests to import `app` from the new package
- fix paths for templates, static files, and data
- update README launch instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68598ae40cc48323a3954621a81e0201